### PR TITLE
Replaced forcewrap() with css solution for better unicode support.

### DIFF
--- a/public_html/forum.php
+++ b/public_html/forum.php
@@ -363,7 +363,7 @@ echo announcement_row($fid,3,4);
 ".        "    $L[TD]>$icon</td>
 ".($showforum?
           "    $L[TD]><a href=forum.php?id=$thread[fid]>$thread[ftitle]</a></td>":'')."
-".        "    $L[TDl]>".($thread[ispoll]?"<img src=img/poll.gif height=10>":"").(($thread[thumbcount])?" (".$thread[thumbcount].") ":"")."<a href=thread.php?id=$thread[id]>".forcewrap(htmlval($thread[title]))."</a>$taglist$pagelist</td>
+".        "    $L[TDl] style=\"word-break: break-all;\">".($thread[ispoll]?"<img src=img/poll.gif height=10>":"").(($thread[thumbcount])?" (".$thread[thumbcount].") ":"")."<a href=\"thread.php?id=$thread[id]\">".htmlval($thread[title])."</a>$taglist$pagelist</td>
 ".        "    $L[TD]>".userlink($thread,'u1',$config[startedbyminipic])."</td>
 ".        "    $L[TD]>$thread[replies]</td>
 ".        "    $L[TD]>$thread[views]</td>

--- a/public_html/lib/perm.php
+++ b/public_html/lib/perm.php
@@ -582,8 +582,8 @@ function perms_for_x($xtype,$xid) {
  function threadlink_by_id($tid) {
  	global $sql;
     $thread = $sql->fetchp("SELECT id,title FROM threads WHERE id=? AND forum IN ".forums_with_view_perm(),array($tid));
-	
-	if ($thread) return "<a href=thread.php?id=$thread[id]>".forcewrap(htmlval($thread[title]))."</a>";
+	//forcewrap() removed. Use CSS in container where this would be called. [Epele]
+	if ($thread) return "<a href=thread.php?id=$thread[id]>".htmlval($thread[title])."</a>";
 	else return 0;
  }
 

--- a/public_html/lib/post.php
+++ b/public_html/lib/post.php
@@ -307,22 +307,6 @@
     return $text;
   }
 
-    function forcewrap($text){
-    $l=0;
-    $text2='';
-    for($i=0;$i<strlen($text);$i++){
-      $text2.=$text[$i];
-      if($text[$i]==' ')
-        $l=0;
-      else{
-        $l++;
-        if(!($l%30))
-          $text2.=' ';
-      }
-    }
-    return $text2;
-  }
-
   function posttoolbutton($e,$name,$title,$leadin,$leadout,$names=""){
     global $L;
     if($names=="") $names=$name;

--- a/public_html/private.php
+++ b/public_html/private.php
@@ -133,7 +133,7 @@ print   "$L[TBL1]>
     print "  $L[$tr]>
 ".        "    $L[TD2]><a href=private.php?action=del&id=$pmsg[id]&showdel=$showdel&view=$_GET[view]><img src=img/delete.png></a></td>
 ".        "    $L[TD1]>$status</td>
-".        "    $L[TDl]><a href=showprivate.php?id=$pmsg[id]>".forcewrap(htmlval($pmsg[title]))."</a></td>
+".        "    $L[TDl] style=\"word-break: break-all;\"><a href=showprivate.php?id=$pmsg[id]>".htmlval($pmsg[title])."</a></td>
 ".        "    $L[TD]>".userlink($pmsg,'u')."</td>
 ".        "    $L[TD]><nobr>".cdate($dateformat,$pmsg['date'])."</nobr></td>
 ";

--- a/public_html/profile.php
+++ b/public_html/profile.php
@@ -86,7 +86,7 @@ if($_COOKIE['pstbon']==-1){
 
    if($pfound && $thread)
     {
-     $lastpostlink = "<br>in <a href=\"thread.php?pid=$thread[id]#$thread[id]\">".forcewrap(htmlval($thread['ttitle']))."</a> 
+     $lastpostlink = "<br>in <a href=\"thread.php?pid=$thread[id]#$thread[id]\">".htmlval($thread['ttitle'])."</a> 
                      (<a href=\"forum.php?id=$thread[forum]\">".htmlval($thread['ftitle'])."</a>)";
     }
    else if($user['posts'] == 0)
@@ -385,7 +385,7 @@ print "    $L[TBL] width=\"100%\">
                    $L[TD2]>".cdate($dateformat, $user['regdate'])." (".timeunits($days * 86400)." ago)
                  $L[TR]>
                    $L[TD1]><b>Last post</b></td>
-                   $L[TD2]>
+                   $L[TD2] style=\"word-break: break-all;\">
                      ".($user['lastpost']? cdate($dateformat, $user['lastpost'])." (".timeunits(ctime() - $user['lastpost'])." ago)" : "None")."
                      $lastpostlink
                  $L[TR]>

--- a/public_html/search.php
+++ b/public_html/search.php
@@ -354,7 +354,7 @@ if (isset($_POST['search'])) {
 				$L[TD1]>$status</td>
 				$L[TD]>$icon</td>
 				$L[TD]><a href='forum.php?id={$thread['forum']}'>{$forums[$thread['forum']]}</a></td>
-				$L[TDl]><a href='thread.php?id={$thread['id']}'>".forcewrap(htmlval($thread['title']))."</a>$taglist$pagelist</td>
+				$L[TDl] style=\"word-break: break-all;\"><a href='thread.php?id={$thread['id']}'>".htmlval($thread['title'])."</a>$taglist$pagelist</td>
 				$L[TD]>".userlink($thread,'u1',$config['startedbyminipic'])."</td>
 				$L[TD]>{$thread['replies']}</td>
 				$L[TD]>{$thread['views']}</td>


### PR DESCRIPTION
There was a few occasions where forcewrap() would cause long unicode strings to become fragmented. This also better ensures that long strings wrap per browser window size.