### PR TITLE
Use consistent token checks everywhere

### DIFF
--- a/public_html/editgroups.php
+++ b/public_html/editgroups.php
@@ -12,7 +12,8 @@
   
   if ($act == 'delete')
   {
-	$id = unpacksafenumeric($_GET['id']);
+	$id = (int) $_GET['id']; //unpacksafenumeric($_GET['id']);
+	check_token($_GET['auth'], $id);
 	$group = $sql->fetchp("SELECT * FROM `group` WHERE `id`=?", array($id));
 	
 	if (!$group)
@@ -109,7 +110,8 @@
  
  if ($act == 'undelete')
   {
-	$id = unpacksafenumeric($_GET['id']);
+	$id = (int) $_GET['id']; //unpacksafenumeric($_GET['id']);
+	check_token($_GET['auth'], $id);
 	$deletedgroup = $sql->fetchp("SELECT * FROM `deletedgroups` WHERE `id`=?", array($id));
  
 	if (!$deletedgroup)
@@ -175,7 +177,7 @@
 		    $bmisc = $deletedgroup['banned'] == 1 ? 'For banned users' : '-'; 
  
 		$actions = array();
-		if ($caneditperms) $actions[] = array('href'=>'editgroups.php?deletedgroups&act=undelete&id='.urlencode(packsafenumeric($deletedgroup['id'])), 'title'=>'Undelete', 
+		if ($caneditperms) $actions[] = array('href'=>"editgroups.php?deletedgroups&act=undelete&id={$group['id']}".auth_url($group['id']), 'title'=>'Undelete', 
 			'confirm'=>'Are you sure you want to undelete the group "'.htmlspecialchars($deletedgroup['title']).'"?');
  
 		$data[] = array
@@ -322,7 +324,7 @@
 		$actions = array();
 		if ($caneditperms) $actions[] = array('href'=>'editperms.php?gid='.$group['id'], 'title'=>'Edit permissions');
 		$actions[] = array('href'=>'editgroups.php?act=edit&id='.$group['id'], 'title'=>'Edit');
-		if ($caneditperms) $actions[] = array('href'=>'editgroups.php?act=delete&id='.urlencode(packsafenumeric($group['id'])), 'title'=>'Delete', 
+		if ($caneditperms) $actions[] = array('href'=>"editgroups.php?act=delete&id={$group['id']}".auth_url($group['id']), 'title'=>'Delete', 
 			'confirm'=>'Are you sure you want to delete the group "'.htmlspecialchars($group['title']).'"? It will be permanently lost as well as all permissions attached to it.');
 		
 		$data[] = array

--- a/public_html/editpost.php
+++ b/public_html/editpost.php
@@ -12,26 +12,22 @@
   require 'lib/threadpost.php';
   loadsmilies();
 
-  if($act=$_POST[action])
-  {
-    $pid=$_POST[pid];  
-	
-	if ($_POST['passenc'] !== md5($pwdsalt2.$loguser['pass'].$pwdsalt))
-		$err = 'Invalid token.';
-  }
-  else
-  {
-    $pid=$_GET[pid];
+  if($act=$_POST['action']) {
+    check_token($_POST['auth']);
+	$pid = (int) $_POST['pid'];  
+  } else {
+    $pid = (int) $_GET['pid'];
   }
   
   $userid = $loguser['id'];
   $user = $loguser;
-  $pass = md5($pwdsalt2.$loguser['pass'].$pwdsalt);
+ // $pass = md5($pwdsalt2.$loguser['pass'].$pwdsalt);
 
-  if($_GET[act]=='delete' || $_GET[act]=='undelete') {
-    $act=$_GET[act];
-    $pid=unpacksafenumeric($pid);
-  }
+	if ($_GET['act'] == 'delete' || $_GET['act'] == 'undelete') {
+		$act = $_GET['act'];
+		check_token($_GET['auth'], $pid);
+		//$pid=unpacksafenumeric($pid);
+	}
 
   checknumeric($pid);
 
@@ -110,10 +106,8 @@ if($loguser[redirtype]==1 && $act=="Submit"){ pageheader('Edit post',$thread[for
 ".        " <form action=editpost.php method=post>
 ".        "  $L[TRh]>
 ".        "    $L[TDh] colspan=2>Edit Post</td>
-";
-    print "  $L[INPh]=name value=\"".htmlval($loguser[name])."\">
-".        "  $L[INPh]=passenc value=\"$pass\">
-";
+".        "    ".auth_tag();
+
     if($loguser[posttoolbar]!=1)
     print "  $L[TR]>
 ".        "    $L[TD1c] width=120>Format:</td>
@@ -183,8 +177,7 @@ print     "  $L[TR]>
 ".        "  $L[TR1]>
 ".        "    $L[TD]>&nbsp;</td>
 ".        "    $L[TD]>
-".        "      $L[INPh]=name value=\"".htmlval(stripslashes($_POST[name]))."\">
-".        "      $L[INPh]=passenc value=\"$pass\">
+".        "      $L[INPh]=auth value=\"".htmlval($_POST['auth'])."\">
 ".        "      $L[INPh]=pid value=$pid>
 ".        "      $L[INPs]=action value=Submit>
 ".        "      $L[INPs]=action value=Preview>

--- a/public_html/editprofile.php
+++ b/public_html/editprofile.php
@@ -46,10 +46,10 @@
         $listgroup[$group['id']] = $group['title'];
       }
 
-  $token = md5($pwdsalt2.$loguser['pass'].$pwdsalt);
+  
   if($_POST[action]=='Edit profile')
   {
-	if ($_POST['token'] !== $token) die('No.');
+	check_token($_POST['auth']);
 	
 	if ($_POST[pass]!='' && $_POST[pass]==$_POST[pass2]&&$targetuserid==$loguser[id])
 		setcookie('pass',packlcookie(md5($pwdsalt2.$_POST[pass].$pwdsalt)),2147483647);
@@ -510,7 +510,7 @@ if ($config['alwaysshowlvlbar'])
 ".        "    $L[TD]>$L[INPs]=action value='Edit profile'>
 ".        "    $L[INPs]=action value='Preview theme'></td>
 ".        " $L[TBLend]
-".        " $L[INPh]=token value='$token'>
+".        " ".auth_tag()."
 ".        "</form>
 ";
   }

--- a/public_html/forum.php
+++ b/public_html/forum.php
@@ -45,6 +45,7 @@
 $isIgnored = $sql->resultq("select count(*) from ignoredforums where uid=".$loguser['id']." and fid=".$fid) == 1;
 if(isset($_GET['ignore']))
 {
+  check_token($_GET['auth'], "xign");
   if(!$isIgnored && $loguser['id']!=0)
   {
     $sql->query("insert into ignoredforums values (".$loguser['id'].", ".$fid.")");
@@ -60,6 +61,7 @@ if(isset($_GET['ignore']))
 }
 else if(isset($_GET['unignore']))
 {
+  check_token($_GET['auth'], "xign");
   if($isIgnored)
   {
     $sql->query("delete from ignoredforums where uid=".$loguser['id']." and fid=".$fid);
@@ -81,8 +83,9 @@ if (has_perm('edit-forums')) {
 }
 
 if($loguser['id']!=0){
-$ignoreLink = $isIgnored ? "<a href=\"forum.php?id=$fid&amp;unignore\" class=\"unignoreforum\">Unignore forum</a> "
-             : "<a href=\"forum.php?id=$fid&amp;ignore\" class=\"ignoreforum\">Ignore forum</a> ";
+	$auth = auth_url("xign");
+	$ignoreLink = $isIgnored ? "<a href=\"forum.php?id=$fid&amp;unignore$auth\" class=\"unignoreforum\">Unignore forum</a> "
+				: "<a href=\"forum.php?id=$fid&amp;ignore$auth\" class=\"ignoreforum\">Ignore forum</a> ";
 }
     $threads=$sql->query("SELECT ".userfields('u1','u1').",".userfields('u2','u2').", t.*, 
 

--- a/public_html/lib/auth.php
+++ b/public_html/lib/auth.php
@@ -66,6 +66,8 @@
     else return $a[0];
   }
   
+  // if you need to use tokens, please use these functions (and make sure the auth key is either in $_GET['auth'] or $_POST['auth'])
+  // DO NOT USE MD5 STUFF DIRECTLY
   function check_token(&$check, $var = '') {
     if ($check != generate_token($var)) {
       error("Error", "Invalid token");
@@ -78,5 +80,5 @@
     //return hash('sha256', $pwdsalt2 . $loguser['pass'] . $_SERVER['REMOTE_ADDR'] . $var . $pwdsalt);
   }
   function auth_tag($var = '') { return "<input type='hidden' name='auth' value=\"".generate_token($var)."\">"; }
-
+  function auth_url($var = '') { return "&auth=".generate_token($var); }
 ?>

--- a/public_html/lib/board.php
+++ b/public_html/lib/board.php
@@ -14,5 +14,10 @@
     return "<a href='$para'><img src='$icon' border='0' style='margin-right:5px' title='$text'></a>"
           ."<link rel='alternate' type='application/rss+xml' title='$text' href='$para'>";
   }
+  
+  function urlformat($url) {
+	$url = preg_replace('/[\?\&]auth(=[0-9a-z]+)/i', '', $url); // don't reveal the token
+	return str_replace(array("%20", "_"), " ", htmlspecialchars($url, ENT_QUOTES));
+  }
 
 ?>

--- a/public_html/lib/common.php
+++ b/public_html/lib/common.php
@@ -716,6 +716,7 @@
 		 <br>
           $oldpmsgbox";
      }
+     define('HEADER_PRINTED', true);
    }
 
   function pagestats()
@@ -755,7 +756,9 @@
   function error($name, $msg)
    {
     global $abversion, $abdate, $boardprog;
-	pageheader('Error');
+    if (!defined('HEADER_PRINTED')) {
+        pageheader('Error');
+    }
     print "<br>";
     noticemsg($name,$msg);
     pagefooter();

--- a/public_html/lib/common.php
+++ b/public_html/lib/common.php
@@ -493,13 +493,13 @@
       if($v[logout]){ print "<a href=\"\"><label for=\"lgout\">Log Out</label></a>"; } else { print "<a href=\"$v[url]\">$v[title]</a>"; }
       $c++;
      }
-
+	 // todo: remove this unnecessary extra mungling
      print "
                </td>
-               <form action=\"login.php\" method=\"post\" name=\"logout\" onsubmit=\"if(!confirm('Do you wish to log out?')){return false;} else {  document.getElementById('lghash').value='".md5($pwdsalt2.$loguser['pass'].$pwdsalt)."'; }\">
+               <form action=\"login.php\" method=\"post\" name=\"logout\" onsubmit=\"if(!confirm('Do you wish to log out?')){return false;} else {  document.getElementById('auth').value='".generate_token("weird")."'; }\">
                  $L[INPh]=\"action\" value=\"logout\">
                  <input type=\"submit\" id=\"lgout\" style=\"display: none;\">
-                 $L[INPh]=\"lghash\" id=\"lghash\" value=\"TurtlesTurtlesTurtles\">
+                 $L[INPh]=\"auth\" id=\"auth\" value=\"TurtlesTurtlesTurtles\">
                </form>";
     
     if ($radar)
@@ -755,7 +755,7 @@
   function error($name, $msg)
    {
     global $abversion, $abdate, $boardprog;
-    pageheader('Error');
+	pageheader('Error');
     print "<br>";
     noticemsg($name,$msg);
     pagefooter();

--- a/public_html/lib/spritelib.php
+++ b/public_html/lib/spritelib.php
@@ -1,8 +1,0 @@
-<?php
-
-function generate_sprite_hash($userid,$spriteid) {
-  global $spritesalt;
-  return md5($spritesalt.$userid.$spriteid.$spritesalt);
-}
-
-?>

--- a/public_html/lib/sprites.php
+++ b/public_html/lib/sprites.php
@@ -27,7 +27,7 @@
  * Common = 0 | Uncommon = 20 | 40 = Slightly Rare | Rare = 60 | Very Rare = 80 | Mew Rare = 99
  */
 
-require_once 'lib/spritelib.php';
+//require_once 'lib/spritelib.php';
 
 $chance = 5 + (rand(0, 6464) % 5);
 
@@ -120,9 +120,6 @@ switch($monData['anchor'])
 
 $monMarkup = "<img id=\"sprite\" style=\"opacity: 0.75; -moz-opacity: 0.75; position: fixed; ".$x."; ".$y."; z-index: 999; max-width: 100%;\" src=\"img/sprites/".$pic."\" title=\"".$monData['title']."\" onclick=\"capture()\" />";
 
-
-$spritehash = generate_sprite_hash($loguser['id'], $monData['id']);
-
 $monScript = "<script language=\"javascript\">
 	function capture()
 	{
@@ -137,7 +134,7 @@ $monScript = "<script language=\"javascript\">
 					alert(x.responseText);
 			}
 		};
-		x.open('GET', 'sprites.php?catch=".$monData['id']."&t=".$spritehash."&x_ajax=1', true);
+		x.open('GET', 'sprites.php?catch=".$monData['id'].auth_url("{$loguser['id']}_{$monData['id']}")."&x_ajax=1', true);
 		x.send(null);
 	}
 </script>";

--- a/public_html/lib/threadpost.php
+++ b/public_html/lib/threadpost.php
@@ -57,12 +57,13 @@ function usegfxnums()
       $post['usign'] = $post['uhead'] = "";
     //}
 
+	$authval = auth_url($post['id']);
     //post has been deleted, display placeholder
     if($post['deleted']) {
       $postlinks="";
       if(can_edit_forum_posts(getforumbythread($post['thread']))) {
         $postlinks.="<a href=\"thread.php?pid={$post['id']}&amp;pin={$post['id']}&rev={$post['revision']}#{$post['id']}\">Peek</a> | ";
-        $postlinks.="<a href=\"editpost.php?pid=".urlencode(packsafenumeric($post['id']))."&amp;act=undelete\">Undelete</a>";
+        $postlinks.="<a href=\"editpost.php?pid={$post['id']}{$authval}&amp;act=undelete\">Undelete</a>";
       }
 
       if($post['id'])
@@ -115,7 +116,7 @@ function usegfxnums()
         $postlinks.=($postlinks?' | ':'')."<a href=\"editannouncetitle.php?pid={$post['id']}\">Edit Title</a>";
 
       if($post['id'] && can_delete_forum_posts(getforumbythread($post['thread'])))
-        $postlinks.=($postlinks?' | ':'')."<a href=\"editpost.php?pid=".urlencode(packsafenumeric($post['id']))."&amp;act=delete\">Delete</a>";
+        $postlinks.=($postlinks?' | ':'')."<a href=\"editpost.php?pid={$post['id']}{$authval}&amp;act=delete\">Delete</a>";
 
       if($post['id'])
         $postlinks.=" | ID: {$post['id']}";

--- a/public_html/login.php
+++ b/public_html/login.php
@@ -28,13 +28,11 @@ if($_COOKIE['pstbon']==-1){
     }
     $print="  $L[TD1c]>$print</td>";
   }elseif($act=='logout'){
-    //Adding security-hash check to the log out function. This requires a correct login attempt to be made first.
-    if($_POST['lghash']==md5($pwdsalt2.$loguser['pass'].$pwdsalt)){
-      setcookie('user',0);
-      setcookie('pass','');
-      die(header("Location: ./"));
-    }
-    $err="Invalid logout request.";
+	// Using the default token function now! (horray for consistency)
+	check_token($_POST['auth'], "weird");
+	setcookie('user',0);
+	setcookie('pass','');
+	die(header("Location: ./"));
   }
 
   pageheader('Login');

--- a/public_html/newreply.php
+++ b/public_html/newreply.php
@@ -11,35 +11,17 @@
   require 'lib/threadpost.php';
   loadsmilies();
 
-  // [Mega-Mario] see my comment in newthread.php
-  if($act=$_POST[action]){
-    $tid=$_POST[tid];
-
-    if ($log)
-	{
-		$userid = $loguser['id'];
-		$user = $loguser;
-		if ($_POST['passenc'] !== md5($pwdsalt2.$loguser['pass'].$pwdsalt))
-			$err = 'Invalid token.';
-			
-		$pass = $_POST['passenc'];
+  	//--
+	if ($act = $_POST['action']) {
+		check_token($_POST['auth']);
+		$tid = (int) $_POST['tid'];
+	} else {
+		$tid = (int) $_GET['id'];
 	}
-	else
-	{
-      $pass=md5($pwdsalt2.$_POST[pass].$pwdsalt);
-
-    if($userid=checkuser($_POST[name],$pass))
-      $user=$sql->fetchq("SELECT * FROM users WHERE id=$userid");
-    else
-      $err="    Invalid username or password!<br>
-".         "    <a href=forum.php?id=$fid>Back to forum</a> or <a href=newthread.php?id=$fid>try again</a>";
-
-		$pass = md5($pwdsalt2.$pass.$pwdsalt);
-	}
-  }else{
-    $user=$loguser;
-    $tid=$_GET[id];
-  }
+	$user   = $loguser;
+	$userid = $loguser['id'];
+	//--
+	
   checknumeric($tid);
 
   needs_login(1);
@@ -158,8 +140,6 @@
     $post[mood] = (isset($_POST[mid]) ? (int)$_POST[mid] : -1); // 2009-07 Sukasa: Newthread preview
     if($act=='Preview') $post[moodlist]=moodlist($_POST[mid]);
     else $post[moodlist]=moodlist();
-    if($act=='Preview') $pass=$_POST[passenc];
-    else $pass=md5($pwdsalt2.$loguser[pass].$pwdsalt);
     $post[nolayout]=$_POST[nolayout];
     $post[close]=$_POST[close];
     $post[stick]=$_POST[stick];
@@ -203,8 +183,7 @@ print     "  $L[TR]>
 ".        "  $L[TR1]>
 ".        "    $L[TD]>&nbsp;</td>
 ".        "    $L[TD]>
-".        "      $L[INPh]=name value=\"".htmlval(stripslashes($_POST[name]))."\">
-".        "      $L[INPh]=passenc value=\"$pass\">
+".        "      ".auth_tag()."
 ".        "      $L[INPh]=tid value=$tid>
 ".        "      $L[INPs]=action value=Submit>
 ".        "      $L[INPs]=action value=Preview>

--- a/public_html/newthread.php
+++ b/public_html/newthread.php
@@ -6,37 +6,17 @@
     $announce=$_REQUEST[announce];
     checknumeric($announce);
 
-	// [Mega-Mario] This is currently useless. TODO: fix or nuke.
-  if($act=$_POST[action])
-  {
-    $fid=$_POST[fid];
-    if ($log)
-	{
-		$userid = $loguser['id'];
-		$user = $loguser;
-		if ($_POST['passenc'] !== md5($pwdsalt2.$loguser['pass'].$pwdsalt))
-			$err = 'Invalid token.';
-			
-		$pass = $_POST['passenc'];
+	//--
+	if ($act = $_POST['action']) {
+		check_token($_POST['auth']);
+		$fid = (int) $_POST['fid'];
+	} else {
+		$fid = (int) $_GET['id'];
 	}
-	else
-	{
-      $pass=md5($pwdsalt2.$_POST[pass].$pwdsalt);
+	$user   = $loguser;
+	$userid = $loguser['id'];
+	//--
 
-    if($userid=checkuser($_POST[name],$pass))
-      $user=$sql->fetchq("SELECT * FROM users WHERE id=$userid");
-    else
-      $err="    Invalid username or password!<br>
-".         "    <a href=forum.php?id=$fid>Back to forum</a> or <a href=newthread.php?id=$fid>try again</a>";
-
-		$pass = md5($pwdsalt2.$pass.$pwdsalt);
-	}
-  }
-  else
-  {
-    $user=$loguser;
-    $fid=$_GET[id];
-  }
   checknumeric($fid);
 
   needs_login(1);
@@ -172,20 +152,7 @@ if($act!="Submit"){
 ".        " $L[TBL1]>
 ".        "  $L[TRh]>
 ".        "    $L[TDh] colspan=2>$typecap</td>
-";
-    if(!$log)
-    print "  $L[TR]>
-".        "    $L[TD1c]>Username:</td>
-".        "    $L[TD2]>$L[INPt]=name size=25 maxlength=25></td>
 ".        "  $L[TR]>
-".        "    $L[TD1c]>Password:</td>
-".        "    $L[TD2]>$L[INPp]=pass size=13 maxlength=32></td>
-";
-    else
-    print "  $L[INPh]=name value=\"".htmlval($loguser[name])."\">
-".        "  $L[INPh]=passenc value=\"".md5($pwdsalt2.$loguser[pass].$pwdsalt)."\">
-";
-    print "  $L[TR]>
 ".        "    $L[TD1c]>$typecap title:</td>
 ".        "    $L[TD2]>$L[INPt]=title size=100 maxlength=100></td>
 ".        "  $L[TR]>
@@ -207,6 +174,7 @@ print     "  $L[TR]>
 ".        "  $L[TR1]>
 ".        "    $L[TD]>&nbsp;</td>
 ".        "    $L[TD]>
+".        "      ".auth_tag()."
 ".        "      $L[INPh]=fid value=$fid>
 ".        "      $L[INPh]=announce value=$announce>
 ".        "      $L[INPs]=action value=Submit>
@@ -311,9 +279,10 @@ print     "  $L[TR]>
 ".        "  $L[TR1]>
 ".        "    $L[TD]>&nbsp;</td>
 ".        "    $L[TD]>
-".        "      $L[INPh]=name value=\"".htmlval(stripslashes($_POST[name]))."\">
-".        "      $L[INPh]=passenc value=\"$pass\">
-".        "      $L[INPh]=fid value=$fid>
+".        "      $L[INPh]=auth value=\"".htmlval($_POST['auth'])."\">
+"./*      "      $L[INPh]=passenc value=\"$pass\">
+".*/
+          "      $L[INPh]=fid value=$fid>
 ".        "      $L[INPh]=iconid value=$_POST[iconid]>
 ".        "      $L[INPh]=iconurl value=$_POST[iconurl]>
 ".        "      $L[INPh]=announce value=$announce>

--- a/public_html/online.php
+++ b/public_html/online.php
@@ -140,6 +140,7 @@ $L[TBL1]>
 	pagefooter();
 
 function urlformat($url) {
+	$url = preg_replace('/[\?\&]auth(=[0-9a-z]+)/i', '', $url); // don't reveal the token
 	return str_replace(array("%20", "_"), " ", htmlspecialchars($url, ENT_QUOTES));
 }	
 function sslicon($ssl) {

--- a/public_html/online.php
+++ b/public_html/online.php
@@ -139,10 +139,6 @@ $L[TBL1]>
 
 	pagefooter();
 
-function urlformat($url) {
-	$url = preg_replace('/[\?\&]auth(=[0-9a-z]+)/i', '', $url); // don't reveal the token
-	return str_replace(array("%20", "_"), " ", htmlspecialchars($url, ENT_QUOTES));
-}	
 function sslicon($ssl) {
 	if (has_perm('view-post-ips') && $ssl) {
 		return "<img src='img/ssloff.gif'>";

--- a/public_html/profile.php
+++ b/public_html/profile.php
@@ -357,7 +357,12 @@ if (\$whateverthislongstupidvariable == \$anotherstupidlylongnamedvariable) //Ep
     if($userdisplayname || $usercnickcolor){
       $showrealnick = true;
     }
-    
+	
+	// extra url mungling to remove token 
+	if ($user['url']) {
+		$user['url'] = urlformat($user['url']);
+    }
+	
     print "<a href=\"./\">Main</a> - Profile for ".userdisp($user)."
            <br><br>
 ";

--- a/public_html/shop.php
+++ b/public_html/shop.php
@@ -377,7 +377,7 @@
 				if ($_GET['action'] == 'edit') {
 					$comm = $edit;
 				} else {
-					$tokenstr = "&auth=".generate_token(TOKEN_SHOP);
+					$tokenstr = auth_url(TOKEN_SHOP);
 					$buy     = "<a href='shop.php?action=buy&id={$item['id']}{$tokenstr}'>Buy</a>";
 					$sell    = "<a href='shop.php?action=sell&cat={$_GET['cat']}{$tokenstr}'>Sell</a>";
 					$preview = "<a href='#status' onclick=\"preview({$loguser['id']},{$item['id']},{$_GET['cat']},'".addslashes($item['name'])."')\">Preview</a>";

--- a/public_html/sprites.php
+++ b/public_html/sprites.php
@@ -4,12 +4,15 @@ require("lib/common.php");
 
 if(isset($_GET['catch']))
 {
-	require('lib/sprites.php');
+
 	$monID = (int)$_GET['catch'];
 	$userID = (int)$loguser['id'];
-	$spritehash = $_GET['t'];
-	if($userID == 0) die("Not logged in.");
-	if($spritehash != generate_sprite_hash($userID,$monID)) die("Not a valid capture.");
+	
+	if ($userID == 0) die("Not logged in.");
+	// this can't use check_token() as it's meant to return text from an alert
+	if ($_GET['auth'] != generate_token("{$userID}_{$monID}")) die("Not a valid capture.");
+	
+	require('lib/sprites.php');
 
 	$sql->query("INSERT IGNORE INTO sprite_captures VALUES(".$userID.", ".$monID.")") or die("Could not register capture.");
 	if($sql->affectedrows() == 1)


### PR DESCRIPTION
to never use md5 directly ever again and reinvent the wheel any time a token needs to be used

also:
- adds token protection to ignore threads functionality
- removes the leftovers of "posting while logged out" from newreply and newthread
- prevents error() from printing the header twice
- fixes the broken logout link (which should be changed anyway)