### PR TITLE
Adding Login session durations; Various fixes and cleanup.

### DIFF
--- a/public_html/editprofileext.php
+++ b/public_html/editprofileext.php
@@ -5,7 +5,7 @@ require("lib/common.php");
 
   $r = request_variables(array('id','action','act'));
   $pagebar = array();
-
+  if($config['extendedprofile']==0) error("Feature Disabled","Extended profile support is not enabled.<br> <a href=./>Back to main</a>");
   if(!has_perm('edit-profileext')) error("Error", "You have no permissions to do this!<br> <a href=./>Back to main</a>");
 
   pageheader("Edit Extended Profile Fields");

--- a/public_html/lcookie.php
+++ b/public_html/lcookie.php
@@ -6,9 +6,9 @@
     needs_login(1);
   }
 
-  if($_POST[action]=="update") {
+  if(checkvar('_POST','action')=="update") {
     $err="";
-    if(!preg_match("/^([0-9|.|,|\*]*)$/",$_POST[ranges]))
+    if(!preg_match("/^([0-9|.|,|\*]*)$/",$_POST['ranges']))
       $err="      Range string contains illegal characters.
 ".         "      <a href=''>Go back</a> or <a href='index.php'>give up</a>.";
 
@@ -18,31 +18,35 @@
       pagefooter();
       die();
     }else{
-      $_COOKIE[pass]=packlcookie(unpacklcookie($_COOKIE[pass]),$_POST[ranges]);
-      setcookie('pass',$_COOKIE[pass],2147483647);
+      switch($_POST['duration']){
+        case 1: $dstr=strtotime('+1 Week'); break;
+        case 2: $dstr=strtotime('+1 Month'); break;
+        case 3: $dstr=strtotime('+1 Year'); break;
+        case 4: $dstr=2147483647; break; //Legacy value
+        default: $dstr=0;
+      }
+      $_COOKIE['pass']=packlcookie(unpacklcookie($_COOKIE['pass']),$_POST['ranges']);
+      setcookie('pass',$_COOKIE['pass'],$dstr);
     }
   }
 
   pageheader('Advanced login cookie setup');
 
-  $d=explode(",",decryptpwd($_COOKIE[pass]));
+  $d=explode(",",decryptpwd($_COOKIE['pass']));
 
-  $data.="$L[TBL1] style='width:200px!important'>
+  $data="$L[TBL1] style='width:200px!important'>
 ".       "  $L[TRh]>
 ".       "    $L[TDh] colspan=2>Current data
 ".       "  $L[TRh]>
 ".       "    $L[TDh]>Field
 ".       "    $L[TDh]>Value
 ".       "  $L[TR1]>
-".       "    $L[TD1c]>generating IP
-".       "    $L[TD2c]>$d[0]
-".       "  $L[TR1]>
-".       "    $L[TD1c]>password hash
-".       "    $L[TD2c]><i>*snip*</i>";
-  for($i=2;strlen($d[$i]);++$i) {
+".       "    $L[TD1c]>Current IP
+".       "    $L[TD2c]>$d[0]";
+  for($i=2;strlen(checkvar('d',$i));++$i) {
     $data.="  $L[TR1]>
-".         "    $L[TD1c]>allowed range
-".         "    $L[TD2c]>".$d[$i];
+".         "    $L[TD1c]>Current range
+".         "    $L[TD2c]>".checkvar('d',$i);
   }
   $data.="$L[TBLend]<br>";
 
@@ -50,12 +54,19 @@
 ".      "<form action='lcookie.php' method='post'>$L[INPh]='action' value='update'>
 ".      "$L[TBL1]>
 ".      "  $L[TRh]>
-".      "    $L[TDh]>Modify allowed ranges
+".      "    $L[TDh] colspan=2>Modify allowed ranges
 ".      "  $L[TR1]>
-".      "    $L[TD2]>$L[INPt]='ranges' value='".implode(",",array_slice($d,2))."' style='width:80%'>$L[INPs] value='Update'>
-".      "            <br><font class='sfont'>Data must be provided as comma-separated IPs without spaces,
-".      "            each potentially ending in a single * wildcard. (e.g. <font color='#C0C020'>127.*,10.0.*,1.2.3.4</font>)
-".      "            Faulty data might result in instant self-destruction of your login cookie.</font>
+".      "    $L[TD1]>Range
+".      "    $L[TD2]>$L[INPt]='ranges' value='".implode(",",array_slice($d,2))."' style='width:120px'>
+".      "  $L[TR1]>
+".           fieldrow('Duration', fieldoption('duration',0,array(0=> 'Session', '1 Week', '1 Month', '1 Year')))."
+".      "  $L[TR1]>
+".      "    $L[TD1]>
+".      "    $L[TD2]>
+".      "            <span class='sfont'>Data must be provided as comma-separated IPs without spaces,
+".      "            each potentially ending in a single * wildcard. (e.g. <span style='color:#C0C020;'>127.*,10.0.*,1.2.3.4</span>)<br>
+".      "            Incorrect data will instantly log you out.</span><br>
+".      "  $L[INPs] value='Update'>
 ".      "$L[TBLend]</form>";
 
   pagefooter();

--- a/public_html/lib/auth.php
+++ b/public_html/lib/auth.php
@@ -75,7 +75,7 @@
   }
   function generate_token($var = '') {
     global $pwdsalt, $pwdsalt2, $loguser;
-	return md5($pwdsalt2 . $loguser['pass'] . $var . $pwdsalt);
+	return md5($pwdsalt2 . checkvar('loguser','pass') . $var . $pwdsalt);
 	// Leaving this alternate hash commented for consistency with other md5 token checks. It can still be enabled just fine.
     //return hash('sha256', $pwdsalt2 . $loguser['pass'] . $_SERVER['REMOTE_ADDR'] . $var . $pwdsalt);
   }

--- a/public_html/lib/common.php
+++ b/public_html/lib/common.php
@@ -67,9 +67,9 @@
   require "lib/timezone.php";
   dobirthdays(); //Called here to account for timezone bugs.
 
-  if($loguser['ppp'] < 1)
+  if(checkvar('loguser','ppp') < 1)
    $loguser['ppp'] = 20;
-  if($loguser['tpp'] < 1)
+  if(checkvar('loguser','tpp') < 1)
    $loguser['tpp'] = 20;
 
    // Moved here since the ipbans page would call pageheader() with themes uninitialized otherwise
@@ -443,7 +443,7 @@
      }
     }
     
-    print $pmsgbox;
+    print checkvar('pmsgbox');
 
     //mark forum read
     checknumeric($fid);
@@ -500,7 +500,7 @@
 		//print (isset($v['html']) ? $v['html'] : );
 	}
 	 
-    if ($radar)
+    if (isset($radar))
      {
       print " 
              $L[TR]>

--- a/public_html/lib/ipbans.php
+++ b/public_html/lib/ipbans.php
@@ -20,6 +20,7 @@
 			//	  header("Location: http://banned.ytmnd.com/");
 			//	  header("Location: http://board.acmlm.org/");
 			//    fuck this shit
+			header("HTTP/1.1 403 Forbidden");
 			die("Sorry, but your IP address appears to be banned from this board.");
 		}
 

--- a/public_html/login.php
+++ b/public_html/login.php
@@ -1,16 +1,23 @@
 <?php
   require 'lib/common.php'; 
   
-  if($_POST['action'] == 'Login'){
+  if(checkvar('_POST','action') == 'Login'){
     if($userid=checkuser($_POST[name],md5($pwdsalt2.$_POST[pass].$pwdsalt))){
-      setcookie('user',$userid,2147483647);
-      setcookie('pass',packlcookie(md5($pwdsalt2.$_POST[pass].$pwdsalt),implode(".",array_slice(explode(".",$_SERVER['REMOTE_ADDR']),0,2)).".*"),2147483647);
+      switch($_POST['duration']){
+        case 1: $dstr=strtotime('+1 Week'); break;
+        case 2: $dstr=strtotime('+1 Month'); break;
+        case 3: $dstr=strtotime('+1 Year'); break;
+        case 4: $dstr=2147483647; break; //Legacy value
+        default: $dstr=0;
+      }
+      setcookie('user',$userid,$dstr);
+      setcookie('pass',packlcookie(md5($pwdsalt2.$_POST[pass].$pwdsalt),implode(".",array_slice(explode(".",$_SERVER['REMOTE_ADDR']),0,2)).".*"),$dstr);
       die(header("Location: ./"));
     }else{
        $err="Invalid username or password, cannot log in.";
     }
     $print="  $L[TD1c]>$print</td>";
-  }elseif($_POST['action'] == 'logout'){
+  }elseif(checkvar('_POST','action') == 'logout'){
 	// Using the default token function now! (horray for consistency)
 	check_token($_POST['auth'], "weird");
 	setcookie('user',0);
@@ -20,7 +27,7 @@
 
 	pageheader('Login');
 	print $cookiemsg;
-	if($err) noticemsg("Error", $err);
+	if(isset($err)) noticemsg("Error", $err);
 	print "$L[TBL1]>
 <form action=login.php method=post>
 ".         "  $L[TRh]>
@@ -31,6 +38,8 @@
 ".         "  $L[TR]>
 ".         "    $L[TD1c]>Password:</td>
 ".         "    $L[TD2]>$L[INPp]=pass size=13 maxlength=32></td>
+".         "  $L[TR]>
+".           fieldrow('Duration', fieldoption('duration',0,array(0=> 'Session', '1 Week', '1 Month', '1 Year')))."
 ".         "  $L[TR1]>
 ".         "    $L[TD]>&nbsp;</td>
 ".         "    $L[TD]>$L[INPs]=action value=Login></td>

--- a/public_html/management.php
+++ b/public_html/management.php
@@ -6,35 +6,39 @@ if (!has_perm('manage-board')) error("Error", "You have no permissions to do thi
 
 pageheader('Management');
 
-$mlinks = array();
-$mlinks[] = array('url' => "updatethemes.php", 'title' => 'Update Themes');
-if (has_perm("edit-forums")) 
-  $mlinks[] = array('url' => "manageforums.php", 'title' => 'Manage forums');
-if (has_perm("edit-ip-bans")) 
-  $mlinks[] = array('url' => "ipbans.php", 'title' => 'Manage IP bans');
+$mlinks = array(); //Please try and keep this alphabetical from now onwards.
+if (has_perm("admin-tools-access")) 
+  $mlinks[] = array('url' => "administratortools.php", 'title' => 'Administrator Tools');
+if (has_perm("edit-badges")) 
+  $mlinks[] = array('url' => "editbadges.php", 'title' => 'Manage badges');
 if (has_perm("edit-calendar-events")) 
   $mlinks[] = array('url' => "editevents.php", 'title' => 'Manage events');
-if (has_perm("edit-smilies")) 
-  $mlinks[] = array('url' => "editsmilies.php", 'title' => 'Manage Smilies');
-if (has_perm("edit-sprites")){ 
-  $mlinks[] = array('url' => "editsprites.php", 'title' => 'Manage sprites');
-  $mlinks[] = array('url' => "editspritecategories.php", 'title' => 'Manage sprite categories'); }
+if (has_perm("edit-profileext") && $config['extendedprofile']!=0) 
+  $mlinks[] = array('url' => "editprofileext.php", 'title' => 'Manage extended profile');
+if (has_perm("edit-forums")) 
+  $mlinks[] = array('url' => "manageforums.php", 'title' => 'Manage forums');
+if (has_perm("edit-groups")) 
+  $mlinks[] = array('url' => "editgroups.php", 'title' => 'Manage groups');
+if (has_perm("edit-ip-bans")) 
+  $mlinks[] = array('url' => "ipbans.php", 'title' => 'Manage IP bans');
 if (has_perm("edit-ranks")){ 
   $mlinks[] = array('url' => "editranks.php", 'title' => 'Manage ranks');
   $mlinks[] = array('url' => "editrankset.php", 'title' => 'Manage ranksets'); }
-if (has_perm("edit-badges")) 
-  $mlinks[] = array('url' => "editbadges.php", 'title' => 'Manage badges');
-if (has_perm("edit-groups")) 
-  $mlinks[] = array('url' => "editgroups.php", 'title' => 'Manage groups');
+if (has_perm("edit-smilies")) 
+  $mlinks[] = array('url' => "editsmilies.php", 'title' => 'Manage smilies');
+if (has_perm("edit-spiders"))
+  $mlinks[] = array('url' => "editspiders.php", 'title' => 'Manage spiders');
+if (has_perm("edit-sprites")){ 
+  $mlinks[] = array('url' => "editsprites.php", 'title' => 'Manage sprites');
+  $mlinks[] = array('url' => "editspritecategories.php", 'title' => 'Manage sprite categories'); }
 if (has_perm("trash-users")) 
   $mlinks[] = array('url' => "trashuser.php", 'title' => 'Trash users');
-if (has_perm("admin-tools-access")) 
-  $mlinks[] = array('url' => "administratortools.php", 'title' => 'Administrator Tools');
+$mlinks[] = array('url' => "updatethemes.php", 'title' => 'Update Themes');
 
 //Inspired by Tierage's dashboard.php in Blargboard Plus. - SquidEmpress
 $mlinkstext = '';
 foreach ($mlinks as $l)
-	$mlinkstext .= ($mlinkstext?' ':'')."<a href=\"{$l['url']}\"</a>$L[INPs]=action value='{$l['title']}'></a>";
+	$mlinkstext .= ($mlinkstext?' ':'')."<a href=\"{$l['url']}\"</a>$L[INPs]=action value='{$l['title']}' style='width: 200px'></a>";
 
 print "$L[TBL1]>
 ".    "  $L[TRh]>$L[TD]>Board management tools

--- a/public_html/online.php
+++ b/public_html/online.php
@@ -95,12 +95,23 @@ $L[TBL1]>
 ";
 
 // Process guests and bots
+	$n=0;
 	$onbot = false;
 	for ($i = 1; $guest = $sql->fetch($guests); $i++) {
 		// Guests come first, then all bots
 		if (!$onbot && $guest['bot']) {
 			$onbot = true;
-			print "$L[TRg]>$L[TDg] colspan=5>Bots</td></tr>";
+			$n=1;
+			print "$L[TBLend]
+<br>
+$L[TBL1]>
+	$L[TRg]>$L[TDg] colspan=5>Bots</td></tr>	$L[TRh]>
+		$L[TDh] style='width: 30px'>#</td>
+		$L[TDh] style='width: 70px; min-width: 150px'>User agent (Browser)</td>
+		$L[TDh] style='width: 70px'>Last view</td>
+		$L[TDh]>URL</td>
+".($showip ? "$L[TDh] style='width: 170px'>IP</td>":'')."
+	</tr>";
 		}
 		
 		// HTTPS urls are marked by !
@@ -123,7 +134,7 @@ $L[TBL1]>
 		
 		print "
 	$L[$tr]>
-		$L[TD1]>{$i}.</td>
+		$L[TD1]>".($n!=0?$n:$i)."</td>
 		$L[TDl]>{$useragent}</td>
 		$L[TD]>".cdate($loguser['timeformat'], $guest['date'])."</td>
 		$L[TDl]>
@@ -136,6 +147,7 @@ $L[TBL1]>
 			<small>".($guest['ipbanned'] ? "(<a href='ipbans.php?ip={$guest['ip']}'>IP banned</a>)" : "<a href='ipbans.php?newip={$guest['ip']}&newreason=online.php%20ban#addban'>IP Ban</a>")."</small>
 		</td>" : '')."
 	</tr>";
+	if($n!=0) $n++;
 	}
 	print "$L[TBLend]";
 


### PR DESCRIPTION
New feature: Login session duration.
At login, Users can now select how long they wish to be logged in for. Values are Session-only, 1 Week/Month/Year.

Extended profile editor now checks to see if the feature is enabled.
Added a few "hidden" pages to the Management tools for those with correct access levels.
Management tools now sorted alphabetically rather than randomly.