### PR TITLE
Updates to ACS system to restrict viewing of current-day results.

### DIFF
--- a/public_html/acs.php
+++ b/public_html/acs.php
@@ -2,9 +2,10 @@
   require 'lib/common.php';
   pageheader('Active users (server time day blocks)');
 
-  $time = $_GET['time'];
-  $past = $_GET['past'];
-  $easymode = $_GET['easymode'];
+  $time = checkvar('_GET','time');
+  $past = checkvar('_GET','past');
+  $easymode = checkvar('_GET','easymode');
+
   checknumeric($time);
   checknumeric($past);
   if($time < 1)
@@ -39,9 +40,15 @@
         $L[TBL1]>
           $L[TR]>
              $L[TD2]><input type=\"submit\" value=\"Show\">: $L[INPt]=\"past\" size=\"3\" maxlength=\"4\" value=\"$past\"> days ago
-                    | $L[INPc]=\"easymode\" id=\"emode\" ".(isset($easymode)?"checked":"")."><label for=\"emode\" title=\"Without this, at most 5 posts per day in any single thread are counted.\">EASY MODE</label>
-        $L[TBLend]</form>";
+                    | $L[INPc]=\"easymode\" id=\"emode\" ".(checkvar('easymode')?"checked":"")."><label for=\"emode\" title=\"Without this, at most 10 posts per day in any single thread are counted.\">EASY MODE</label>
+        $L[TBLend]</form><br>";
 
+  if(!has_perm('view-current-acs') && $past==0){
+    print "$L[TBL1]>
+           $L[TRh]>$L[TDh]>Notice
+               $L[TR1c]>
+                 $L[TD]>Current day results are unavailable for viewing.";
+  } else {
   print "Active users on ".cdate($loguser['dateformat'], ctime() - $past * 86400).":
          $L[TBL1]>
            $L[TRh]>
@@ -54,7 +61,7 @@
   $q = 1;
   $p =- 1;
   for($i=1;$user=$sql->fetch($users);$i++){
-    if($p!=$user[num]) {
+    if($p!=$user['num']) {
       if($q<=5 && $i>5) {
         print "
                $L[TR1c]>
@@ -79,6 +86,7 @@
              $L[$tdtype]>$user[posts]</b></td>
 ";
     $p = $user['num'];
+  }
   }
   print "$L[TBLend]";
 

--- a/public_html/acs.php
+++ b/public_html/acs.php
@@ -4,6 +4,7 @@
 
   $time = checkvar('_GET','time');
   $past = checkvar('_GET','past');
+  if(!has_perm('view-current-acs') && !isset($_GET['past'])) $past=1;
   $easymode = checkvar('_GET','easymode');
 
   checknumeric($time);

--- a/public_html/frank.php
+++ b/public_html/frank.php
@@ -37,7 +37,8 @@
     } else {
         $day = 32; //We'll correct this after checking if the year is a leap year.
     }
-        
+    //Current day timing for incomplete day notice.
+    $curday=(ctime() - (dtime(ctime())%86400));
     
     $mtstamp = mktime(0,0,0,$month,1,$year);
     $mdays = intval(date('t', $mtstamp));
@@ -86,21 +87,31 @@
   $users=$sql->query($query);
   $pqry=@$sql->result($sql->query("SELECT count(*) FROM posts WHERE date>".($dstr-(dtime($dstr)%86400))." AND date<".($dstr-(dtime($dstr)%86400-86400))),0,0);
 
-            print " -- <i>Total Posts: $pqry</i><table>";
- $q=1; $p=-1;
-  for($i=1;$user=$sql->fetch($users);$i++){
-    if($user['num']!=$p) $q=$i;
-    if($q<=5) {
-    if($mday <= $day){
-	$uid=$user['id'];
-	if(isset($points[$uid])) $points[$uid]=$points[$uid]+$kcspoints[$q]; else $points[$uid]=$kcspoints[$q];
-    }
-    print
-	"<tr><td>$q</td><td>".userlink($user)."</td><td>$user[num]</td></tr>";
-    $p=$user['num'];
+
+  print " -- <i>Total Posts: $pqry</i>";
+  $viewday=$dstr-(dtime($dstr)%86400);
+  $viewcur=0;
+  if(!($curday < $viewday) && !($curday > $viewday)){
+    print "<br><i>Day currently in progress.</i><br>";
+    $viewcur=1;
   }
-}
-        print "</table></td>\n";
+  if(has_perm('view-current-acs') || $viewcur==0){
+    print "<table>";
+    $q=1; $p=-1;
+    for($i=1;$user=$sql->fetch($users);$i++){
+      if($user['num']!=$p) $q=$i;
+      if($q<=5) {
+        if($mday <= $day){
+          $uid=$user['id'];
+          if(isset($points[$uid])) $points[$uid]=$points[$uid]+$kcspoints[$q]; else $points[$uid]=$kcspoints[$q];
+        }
+        print "<tr><td>$q</td><td>".userlink($user)."</td><td>$user[num]</td></tr>";
+        $p=$user['num'];
+      }
+    }
+    print "</table></td>\n";
+  }
+
         
     }
     

--- a/public_html/frank.php
+++ b/public_html/frank.php
@@ -160,12 +160,20 @@
 	.') inter GROUP BY id ORDER BY num DESC';
   $users=$sql->query($query);
   $pqry=@$sql->result($sql->query("SELECT count(*) FROM posts WHERE date>".($dstr-(dtime($dstr)%86400))." AND date<".($dstr-(dtime($dstr)%86400-86400))),0,0);
+//Check that the report is not day-in-progress.
+  $viewday=$dstr-(dtime($dstr)%86400);
+  $viewcur=0;
+  if(!($curday > $viewday)){ $viewcur=1; }
+
+if(has_perm('view-current-acs') || $viewcur==0){
 	print "$L[TBL] width=\"100%\">
 ".        "    $L[TRh]>
-".        "        $L[TDc] colspan=2>KCS Report for $monthnames[$month] $year</td>
+".        "        $L[TDc] colspan=2>Forum Rankings report for $monthnames[$month] $year</td>
 ".        "    </tr>
 ".        "    $L[TR]>
-$L[TD2l]>".strtoupper($monthnames[$month])." $day<hr style=\"width: 100px; margin-left: 0px;\">Total amount of posts: $pqry<br><br><table cellspacing=0>";
+$L[TD2l] style=\"vertical-align: top\">";
+  if($viewcur==1){ print "<i>Day is currently in progress. Results may vary.</i><br>"; }
+  print strtoupper($monthnames[$month])." $day<hr style=\"width: 100px; margin-left: 0px;\">Total amount of posts: $pqry<br><br><table cellspacing=0>";
 $report=strtoupper($monthnames[$month])." $day<hr style=\"width: 100px; margin-left: 0px;\">Total amount of posts: $pqry<br><br><table cellspacing=0>";
 //Results for posts
  $q=1; $p=-1;
@@ -213,5 +221,15 @@ foreach($points as $usr => $pnts){
 ".        "<textarea style=\"width: 100%; height: 400px;\" readonly=\"readonly\">$report</textarea></td>
 ".        "    </tr>
 ".         $L['TBLend'];
+} else {
+	print "$L[TBL] width=\"100%\">
+".        "    $L[TRh]>
+".        "        $L[TDc]>Forum Rankings report for $monthnames[$month] $year</td>
+".        "    </tr>
+".        "    $L[TR]>
+$L[TD2l]>Results for selected date are unavailable.<br>This may be due to the day being in progress, or a future date has been selected.
+".        "    </tr>
+".         $L['TBLend'];
+}
     pagefooter();
 ?>

--- a/public_html/newthread.php
+++ b/public_html/newthread.php
@@ -129,7 +129,7 @@ if($act!="Submit"){
     print "$top - Error";
     noticemsg("Error", $err);
   }elseif(!$act){
-    if(checkvar('$ispoll')){
+    if(checkvar('ispoll')){
       $pollin=
           "$L[TR]>
 ".        "  $L[TD1c]>Poll question:</td>

--- a/sql/perm_update-190223.sql
+++ b/sql/perm_update-190223.sql
@@ -1,0 +1,1 @@
+INSERT INTO `perm` (`id`, `title`, `description`, `permcat_id`, `permbind_id`) VALUES ('view-current-acs', 'View current ACS Day', 'Enables the user to live preview the current ACS day.', '2', '');


### PR DESCRIPTION
Forum Rankings (frank.php) will display a notice that the current day is in progress.
ACS Rankings page will also prevent users without permission from viewing the current day, while defaulting to previous - complete - day.

Includes sql file to add permission to database, but will function without it.