### PR TITLE
Replaced mcrypt with openssl solution.

### DIFF
--- a/public_html/lib/auth.php
+++ b/public_html/lib/auth.php
@@ -3,18 +3,12 @@
 
  function encryptpwd($pass){
     global $config;
-    /*$iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_ECB);
-    $iv      = mcrypt_create_iv($iv_size, MCRYPT_RAND);
-    return trim(base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_256, $config['ckey'], $pass, MCRYPT_MODE_ECB, $iv)));*/
-    return trim(base64_encode($pass));
+    return trim(base64_encode(openssl_encrypt($pass,$config['osslcipher'],$config['ckey'],$options=0,$config['civ'])));
   }
 
   function decryptpwd($pass){
     global $config;
-    /*$iv_size = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_256, MCRYPT_MODE_ECB);
-    $iv      = mcrypt_create_iv($iv_size, MCRYPT_RAND);
-    return trim(mcrypt_decrypt(MCRYPT_RIJNDAEL_256, $config['ckey'], base64_decode($pass), MCRYPT_MODE_ECB, $iv));*/
-    return trim(base64_decode($pass));
+    return trim(openssl_decrypt(base64_decode($pass),$config['osslcipher'],$config['ckey'],$options=0,$config['civ']));
   }
 
   function packlcookie($pass){

--- a/public_html/lib/config.sample.php
+++ b/public_html/lib/config.sample.php
@@ -46,7 +46,10 @@
   $puzzle = $puzzleVariations[array_rand($puzzleVariations)]; 
   
   $config['log']    = 0; // Enables logging to the database of moderator & administrative actions. 0=off; 1=profile; 2=thread & post; 5=access
-  $config['ckey']   = "Change this key!"; // Must be exactly 16, 24 or 32 characters, otherwise logging in won't work
+  $config['ckey']   = "Change this key!"; // Cipher key. Change this phrase for security. Changing this key will invalidate all previous logins.
+  $config['osslcipher'] = "aes-128-cbc"; //Type of OpenSSL cipher. An invalid type will result in logins not working.
+  $config['civ'] = "Change this key!"; //Initialization Vector for OpenSSL cipher. aes-128-cbc requires this to be exactly 16 characters long.
+
   $config['address']   = "url";  // Hostname or IP address of your server (this will be public, required for rss feeds to function correctly)
   $config['base']   = "http://".$config['address']; // Replace if you need fine control of the address
   $config['sslbase']= "https://".$config['address']; // Replace if you need fine control of the address


### PR DESCRIPTION
Board owners should consider running a script containing the following to see what their server supports.
`print_r(openssl_get_cipher_methods())`
This also will result in the initilisation vector size changing for some types of cipher and thus the 'civ' setting will need adjusting accordingly.
The function will automatically pad or trunctate the provided initilisation vector, but will generate warnings every page load as a result.